### PR TITLE
changed master to main in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Your work in the course will be completed in this workspace. Instructions for th
    - Mac: `Command+Shift+P`
 2. Begin typing in `Git: Pull From...` and press `Enter` once it is the first option. 
 3. Begin typing in `origin` and press `Enter` once it is the first option.
-4. Press enter with `origin/master` as the first option.
+4. Press enter with `origin/main` as the first option.
 5. This downloads the latest course materials! It will succeed silently, so if nothing appears to happen it worked (and any new files will be available in the file explorer). If there was an error, you would see an error message pop up.
 
 ## Setup Backup Course Material Repository


### PR DESCRIPTION
The default master branch in Github has been deprecated (switched to main.) Might confuse students attempting to pull from master.